### PR TITLE
Fix typo

### DIFF
--- a/format-sdcard.sh
+++ b/format-sdcard.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Format a microSD card for the BeagelBone Black
-# Mastering Mebedded Linux Programming
+# Mastering Embedded Linux Programming
 # Copyright (c) Chris Simmonds, 2017
 
 if [ $# -ne 1 ]; then


### PR DESCRIPTION
Fixing a minor typo on the format-sdcard bash script.

Mebedded -> Embedded